### PR TITLE
Persist log level filters with Supabase async storage

### DIFF
--- a/packages/ui/src/lib/preferences.ts
+++ b/packages/ui/src/lib/preferences.ts
@@ -1,0 +1,22 @@
+import { localStorageAdapter } from '@supabase/auth-js/dist/module/lib/local-storage'
+
+const LEVELS_KEY = 'logpanel.selectedLevels'
+
+export async function saveSelectedLevels(levels: string[]) {
+  try {
+    await localStorageAdapter.setItem(LEVELS_KEY, JSON.stringify(levels))
+  } catch (e) {
+    console.error('Failed to save levels', e)
+  }
+}
+
+export async function loadSelectedLevels(): Promise<string[] | null> {
+  try {
+    const value = await localStorageAdapter.getItem(LEVELS_KEY)
+    if (!value) return null
+    return JSON.parse(value)
+  } catch (e) {
+    console.error('Failed to load levels', e)
+    return null
+  }
+}

--- a/packages/ui/src/pages/log-viewer.tsx
+++ b/packages/ui/src/pages/log-viewer.tsx
@@ -10,6 +10,7 @@ import DemoControls from "@/components/demo-controls";
 import FloatingTestPanel from "@/components/floating-test-panel";
 import { useRuns, useLogs, useClearLogs } from "@/hooks/use-contract-logs";
 import { useToast } from "@/hooks/use-toast";
+import { loadSelectedLevels, saveSelectedLevels } from "@/lib/preferences";
 import type { Log } from "@shared/schema";
 
 export default function LogViewer() {
@@ -27,6 +28,20 @@ export default function LogViewer() {
   if (!selectedRunId && runs.length > 0) {
     setSelectedRunId(runs[0].run_id);
   }
+
+  // Load saved log level filters on mount
+  useEffect(() => {
+    loadSelectedLevels().then((levels) => {
+      if (levels && Array.isArray(levels) && levels.length > 0) {
+        setSelectedLevels(levels)
+      }
+    })
+  }, [])
+
+  // Persist log level filters whenever they change
+  useEffect(() => {
+    saveSelectedLevels(selectedLevels)
+  }, [selectedLevels])
 
   const toggleLevel = (level: string, checked: boolean) => {
     setSelectedLevels(prev => {


### PR DESCRIPTION
## Summary
- add a small preferences helper that wraps Supabase's `localStorageAdapter`
- load and save log level selections in `LogViewer` so the INFO/WARN/ERROR filters persist between sessions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866d4cb54ec832688399fdb8d0a550f